### PR TITLE
feat: 갤러리 사진별 메모 feature 추가

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -37,6 +37,8 @@ dependencies {
     implementation(libs.material)
     implementation(libs.activity)
     implementation(libs.constraintlayout)
+    implementation(libs.glide)
+    annotationProcessor(libs.compiler)
     testImplementation(libs.junit)
     androidTestImplementation(libs.ext.junit)
     androidTestImplementation(libs.espresso.core)

--- a/app/src/main/java/com/example/madcamp24_week1/GalleryAdapter.java
+++ b/app/src/main/java/com/example/madcamp24_week1/GalleryAdapter.java
@@ -14,6 +14,8 @@ import androidx.annotation.NonNull;
 import androidx.appcompat.app.AlertDialog;
 import androidx.recyclerview.widget.RecyclerView;
 
+import com.bumptech.glide.Glide;
+
 import java.util.List;
 
 public class GalleryAdapter extends RecyclerView.Adapter<GalleryAdapter.ImageViewHolder> {
@@ -35,7 +37,10 @@ public class GalleryAdapter extends RecyclerView.Adapter<GalleryAdapter.ImageVie
     @Override
     public void onBindViewHolder(@NonNull ImageViewHolder holder, int position) {
         GalleryDTO currentItem = imageList.get(position);
-        holder.imageView.setImageResource(currentItem.getImageResId());
+        Glide.with(context)
+                .load(currentItem.getImageResId())
+                .thumbnail(0.1f)
+                .into(holder.imageView);
 
         holder.imageView.setOnClickListener(new View.OnClickListener() {
             @Override
@@ -49,7 +54,10 @@ public class GalleryAdapter extends RecyclerView.Adapter<GalleryAdapter.ImageVie
                 EditText etMemo = dialogView.findViewById(R.id.etMemo);
                 Button btnSave = dialogView.findViewById(R.id.btnSave);
 
-                ivPic.setImageResource(currentItem.getImageResId());
+                Glide.with(context)
+                        .load(currentItem.getImageResId())
+                        .into(ivPic);
+                // ivPic.setImageResource(currentItem.getImageResId());
                 String memo = currentItem.getMemo();
                 if (memo.isEmpty()) {
                     tvMemo.setVisibility(View.VISIBLE);

--- a/app/src/main/java/com/example/madcamp24_week1/GalleryAdapter.java
+++ b/app/src/main/java/com/example/madcamp24_week1/GalleryAdapter.java
@@ -4,7 +4,11 @@ import android.content.Context;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.inputmethod.InputMethodManager;
+import android.widget.Button;
+import android.widget.EditText;
 import android.widget.ImageView;
+import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AlertDialog;
@@ -39,7 +43,57 @@ public class GalleryAdapter extends RecyclerView.Adapter<GalleryAdapter.ImageVie
                 View dialogView = View.inflate(context, R.layout.dialog, null);
                 AlertDialog.Builder dlg = new AlertDialog.Builder(context);
                 ImageView ivPic = dialogView.findViewById(R.id.ivPic);
+
+                TextView tvMemo = dialogView.findViewById(R.id.tvMemo);
+                EditText etMemo = dialogView.findViewById(R.id.etMemo);
+                Button btnSave = dialogView.findViewById(R.id.btnSave);
+
                 ivPic.setImageResource(currentItem.getImageResId());
+                String memo = currentItem.getMemo();
+                if (memo.isEmpty()) {
+                    tvMemo.setVisibility(View.VISIBLE);
+                    etMemo.setVisibility(View.GONE);
+                    btnSave.setVisibility(View.GONE);
+                    tvMemo.setText("Write your memo here...");
+                } else {
+                    tvMemo.setText(memo);
+                }
+
+                tvMemo.setOnClickListener(new View.OnClickListener() {
+                    @Override
+                    public void onClick(View v) {
+                        tvMemo.setVisibility(View.GONE);
+                        etMemo.setVisibility(View.VISIBLE);
+                        btnSave.setVisibility(View.VISIBLE);
+                        etMemo.setText(tvMemo.getText().toString());
+
+                        // Show the keyboard
+                        etMemo.requestFocus();
+                        InputMethodManager imm = (InputMethodManager) context.getSystemService(Context.INPUT_METHOD_SERVICE);
+                        if (imm != null) {
+                            imm.showSoftInput(etMemo, InputMethodManager.SHOW_IMPLICIT);
+                        }
+                    }
+                });
+
+                btnSave.setOnClickListener(new View.OnClickListener() {
+                    @Override
+                    public void onClick(View v) {
+                        String newMemo = etMemo.getText().toString();
+                        currentItem.setMemo(newMemo);
+                        tvMemo.setText(newMemo);
+                        tvMemo.setVisibility(View.VISIBLE);
+                        etMemo.setVisibility(View.GONE);
+                        btnSave.setVisibility(View.GONE);
+
+                        // Hide the keyboard
+                        InputMethodManager imm = (InputMethodManager) context.getSystemService(Context.INPUT_METHOD_SERVICE);
+                        if (imm != null) {
+                            imm.hideSoftInputFromWindow(etMemo.getWindowToken(), 0);
+                        }
+                    }
+                });
+
                 dlg.setTitle("View Photo");
                 dlg.setIcon(R.drawable.ic_launcher_foreground);
                 dlg.setView(dialogView);

--- a/app/src/main/java/com/example/madcamp24_week1/GalleryAdapter.java
+++ b/app/src/main/java/com/example/madcamp24_week1/GalleryAdapter.java
@@ -43,6 +43,7 @@ public class GalleryAdapter extends RecyclerView.Adapter<GalleryAdapter.ImageVie
                 View dialogView = View.inflate(context, R.layout.dialog, null);
                 AlertDialog.Builder dlg = new AlertDialog.Builder(context);
                 ImageView ivPic = dialogView.findViewById(R.id.ivPic);
+                ivPic.setScaleType(ImageView.ScaleType.FIT_CENTER);
 
                 TextView tvMemo = dialogView.findViewById(R.id.tvMemo);
                 EditText etMemo = dialogView.findViewById(R.id.etMemo);
@@ -95,7 +96,6 @@ public class GalleryAdapter extends RecyclerView.Adapter<GalleryAdapter.ImageVie
                 });
 
                 dlg.setTitle("View Photo");
-                dlg.setIcon(R.drawable.ic_launcher_foreground);
                 dlg.setView(dialogView);
                 dlg.setNegativeButton("Close", null);
                 dlg.show();

--- a/app/src/main/java/com/example/madcamp24_week1/GalleryDTO.java
+++ b/app/src/main/java/com/example/madcamp24_week1/GalleryDTO.java
@@ -2,13 +2,23 @@ package com.example.madcamp24_week1;
 
 public class GalleryDTO {
     private int imageResId;
+    private String memo;
 
     public GalleryDTO(int imageResId) {
         this.imageResId = imageResId;
+        this.memo = "";
     }
 
     public int getImageResId() {
         return imageResId;
+    }
+
+    public String getMemo() {
+        return memo;
+    }
+
+    public void setMemo(String memo) {
+        this.memo = memo;
     }
 
 }

--- a/app/src/main/res/layout/dialog.xml
+++ b/app/src/main/res/layout/dialog.xml
@@ -2,12 +2,51 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:gravity="center"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:padding="16dp">
 
     <ImageView
         android:id="@+id/ivPic"
         android:layout_width="match_parent"
-        android:layout_height="600dp"/>
+        android:layout_height="wrap_content"
+        android:layout_centerHorizontal="true"
+        android:adjustViewBounds="true"
+        android:scaleType="centerCrop" />
+
+    <EditText
+        android:id="@+id/etMemo"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_below="@id/ivPic"
+        android:layout_marginTop="8dp"
+        android:hint="Write your memo here..."
+        android:visibility="gone"
+        android:background="@android:color/transparent"
+        android:textColorHint="@android:color/darker_gray"/>
+
+    <TextView
+        android:id="@+id/tvMemo"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_below="@id/ivPic"
+        android:layout_marginTop="8dp"
+        android:background="@android:color/transparent"
+        android:textColor="@android:color/black"
+        android:textSize="16sp"
+        android:hint="Write your memo here..."
+        android:textColorHint="@android:color/darker_gray"
+        android:visibility="visible"/>
+
+    <Button
+        android:id="@+id/btnSave"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentEnd="true"
+        android:layout_below="@id/ivPic"
+        android:layout_marginTop="8dp"
+        android:layout_marginStart="8dp"
+        android:text="Save"
+        android:visibility="gone"/>
 
 
 </RelativeLayout>

--- a/app/src/main/res/layout/dialog.xml
+++ b/app/src/main/res/layout/dialog.xml
@@ -8,19 +8,20 @@
     <ImageView
         android:id="@+id/ivPic"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="350dp"
         android:layout_centerHorizontal="true"
-        android:adjustViewBounds="true"
-        android:scaleType="centerCrop" />
+        android:adjustViewBounds="true"/>
 
     <EditText
         android:id="@+id/etMemo"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="50dp"
         android:layout_below="@id/ivPic"
+        android:layout_toStartOf="@id/btnSave"
         android:layout_marginTop="8dp"
         android:hint="Write your memo here..."
         android:visibility="gone"
+        android:textSize="16sp"
         android:background="@android:color/transparent"
         android:textColorHint="@android:color/darker_gray"/>
 
@@ -29,7 +30,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_below="@id/ivPic"
-        android:layout_marginTop="8dp"
+        android:layout_marginTop="10dp"
         android:background="@android:color/transparent"
         android:textColor="@android:color/black"
         android:textSize="16sp"
@@ -43,7 +44,7 @@
         android:layout_height="wrap_content"
         android:layout_alignParentEnd="true"
         android:layout_below="@id/ivPic"
-        android:layout_marginTop="8dp"
+        android:layout_marginTop="10dp"
         android:layout_marginStart="8dp"
         android:text="Save"
         android:visibility="gone"/>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,7 @@ appcompat = "1.6.1"
 material = "1.10.0"
 activity = "1.8.0"
 constraintlayout = "2.1.4"
+glide = "4.12.0"
 
 [libraries]
 junit = { group = "junit", name = "junit", version.ref = "junit" }
@@ -16,6 +17,9 @@ appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "a
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }
 activity = { group = "androidx.activity", name = "activity", version.ref = "activity" }
 constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "constraintlayout" }
+glide = { group = "com.github.bumptech.glide", name = "glide", version.ref = "glide" }
+compiler = { group = "com.github.bumptech.glide", name = "compiler", version.ref = "glide" }
+
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
갤러리 내의 사진을 선택했을 때, 해당 사진마다 메모를 저장할 수 있는 기능을 추가하였습니다.
동일한 사진을 다시 선택할 시 이전에 저장했던 메모가 표시됩니다.

---
- Layout 변경
dialog 에서 보여주는 view에 텍스트 편집기와 저장된 메모를 보여주는 textview 를 추가하였습니다. 적절한 배치를 위해 RelativeLayout으로 레이아웃 유형을 변경하였습니다.

- GalleryAdapter 변경
onClick 핸들러 내에서 텍스트 편집 및 저장이 가능하도록 추가했습니다. 또, save 버튼 클릭 시 키보드가 사라지도록 내부에 onClick 핸들러를 추가했습니다.

- GalleryDTO 변경
처음엔 Hashmap으로 메모를 저장할까 하다가, 어차피 사진별로 메모를 저장하니, 개별 이미지 클래스인 GalleryDTO 내부에 memo 를 추가했습니다. setMemo, getMemo 메소드를 통해 adapter에서 메모를 불러와 표시하거나 새로운 메모를 저장할 수 있습니다.
---

아래는 virtual device 로 실행한 예시 화면입니다.

<img width="126" alt="image" src="https://github.com/Cheoroo/madcamp24-week1/assets/123471324/a6c08f38-b82c-4703-852f-8a63be6028c7">
<img width="124" alt="image" src="https://github.com/Cheoroo/madcamp24-week1/assets/123471324/9d4148a5-43ac-4959-8fca-16b4fc826e4f">
<img width="128" alt="image" src="https://github.com/Cheoroo/madcamp24-week1/assets/123471324/025121c4-d5d3-4d7f-86e7-735fa02ac856">

