### PR TITLE
Fix: 지도 이미지 사라지는 버그 해결

### DIFF
--- a/app/src/main/java/com/example/madcamp24_week1/RegionFragment.java
+++ b/app/src/main/java/com/example/madcamp24_week1/RegionFragment.java
@@ -32,36 +32,19 @@ public class RegionFragment extends Fragment {
         ImageView ivJeolla = view.findViewById(R.id.regionJeolla);
         ImageView ivJeju = view.findViewById(R.id.regionJeju);
 
-        ivSeoul.setOnClickListener(v -> regionClickHandler(regionList.get(0), ivSeoul, ivGyeonggi, ivGangwon, ivChungcheong, ivGyeongsang, ivJeolla, ivJeju));
-        ivGyeonggi.setOnClickListener(v -> regionClickHandler(regionList.get(1), ivSeoul, ivGyeonggi, ivGangwon, ivChungcheong, ivGyeongsang, ivJeolla, ivJeju));
-        ivGangwon.setOnClickListener(v -> regionClickHandler(regionList.get(2), ivSeoul, ivGyeonggi, ivGangwon, ivChungcheong, ivGyeongsang, ivJeolla, ivJeju));
-        ivChungcheong.setOnClickListener(v -> regionClickHandler(regionList.get(3), ivSeoul, ivGyeonggi, ivGangwon, ivChungcheong, ivGyeongsang, ivJeolla, ivJeju));
-        ivGyeongsang.setOnClickListener(v -> regionClickHandler(regionList.get(4), ivSeoul, ivGyeonggi, ivGangwon, ivChungcheong, ivGyeongsang, ivJeolla, ivJeju));
-        ivJeolla.setOnClickListener(v -> regionClickHandler(regionList.get(5), ivSeoul, ivGyeonggi, ivGangwon, ivChungcheong, ivGyeongsang, ivJeolla, ivJeju));
-        ivJeju.setOnClickListener(v -> regionClickHandler(regionList.get(6), ivSeoul, ivGyeonggi, ivGangwon, ivChungcheong, ivGyeongsang, ivJeolla, ivJeju));
+        ivSeoul.setOnClickListener(v -> regionClickHandler(regionList.get(0)));
+        ivGyeonggi.setOnClickListener(v -> regionClickHandler(regionList.get(1)));
+        ivGangwon.setOnClickListener(v -> regionClickHandler(regionList.get(2)));
+        ivChungcheong.setOnClickListener(v -> regionClickHandler(regionList.get(3)));
+        ivGyeongsang.setOnClickListener(v -> regionClickHandler(regionList.get(4)));
+        ivJeolla.setOnClickListener(v -> regionClickHandler(regionList.get(5)));
+        ivJeju.setOnClickListener(v -> regionClickHandler(regionList.get(6)));
 
         return view;
     }
 
-    private void regionClickHandler(
-        RegionDTO region,
-        ImageView ivSeoul,
-        ImageView ivGyeonggi,
-        ImageView ivGangwon,
-        ImageView ivChungcheong,
-        ImageView ivGyeongsang,
-        ImageView ivJeolla,
-        ImageView ivJeju
-    ) {
+    private void regionClickHandler(RegionDTO region) {
         if (getActivity() instanceof OnRegionSelectedListener) {
-            Log.d("RegionFragment", "this region name: " + region.getName());
-            ivSeoul.setVisibility(View.GONE);
-            ivGyeonggi.setVisibility(View.GONE);
-            ivGangwon.setVisibility(View.GONE);
-            ivChungcheong.setVisibility(View.GONE);
-            ivGyeongsang.setVisibility(View.GONE);
-            ivJeolla.setVisibility(View.GONE);
-            ivJeju.setVisibility(View.GONE);
             ((OnRegionSelectedListener) getActivity()).onRegionSelected(region.getId());
         }
     }

--- a/app/src/main/res/layout/fragment_region.xml
+++ b/app/src/main/res/layout/fragment_region.xml
@@ -11,87 +11,90 @@
         android:layout_width="155dp"
         android:layout_height="150dp"
         android:layout_gravity="center"
-        android:layout_marginLeft="109dp"
-        android:layout_marginTop="108dp"
+        android:layout_marginStart="40dp"
+        android:layout_marginBottom="193dp"
         android:src="@drawable/gangwon"
-        app:layout_constraintLeft_toLeftOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent" />
 
     <ImageView
         android:id="@+id/regionChungcheong"
         android:layout_width="145dp"
         android:layout_height="87dp"
         android:layout_gravity="center"
-        android:layout_marginLeft="64dp"
-        android:layout_marginTop="215dp"
+        android:layout_marginEnd="60dp"
+        android:layout_marginBottom="40dp"
         android:src="@drawable/chungcheong"
-        app:layout_constraintLeft_toLeftOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent" />
 
     <ImageView
         android:id="@+id/regionJeolla"
         android:layout_width="107dp"
         android:layout_height="130dp"
         android:layout_gravity="center"
-        android:layout_marginLeft="61dp"
-        android:layout_marginTop="290dp"
+        android:layout_marginEnd="105dp"
+        android:layout_marginTop="156dp"
         android:src="@drawable/jeolla"
-        app:layout_constraintLeft_toLeftOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent" />
 
     <ImageView
         android:id="@+id/regionJeju"
         android:layout_width="50dp"
         android:layout_height="28dp"
         android:layout_gravity="center"
-        android:layout_marginLeft="65dp"
-        android:layout_marginTop="472dp"
+        android:layout_marginEnd="150dp"
+        android:layout_marginTop="430dp"
         android:src="@drawable/jeju"
-        app:layout_constraintLeft_toLeftOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent" />
 
     <ImageView
         android:id="@+id/regionGyeongsang"
         android:layout_width="114dp"
         android:layout_height="169dp"
         android:layout_gravity="center"
-        android:layout_marginLeft="152dp"
-        android:layout_marginTop="224dp"
+        android:layout_marginStart="85dp"
+        android:layout_marginTop="60dp"
         android:src="@drawable/gyeongsang"
-        app:layout_constraintLeft_toLeftOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent" />
 
     <ImageView
         android:id="@+id/regionGyeonggi"
         android:layout_width="90dp"
         android:layout_height="100dp"
         android:layout_gravity="center"
-        android:layout_marginLeft="75dp"
-        android:layout_marginTop="138dp"
+        android:layout_marginEnd="92dp"
+        android:layout_marginBottom="182dp"
         android:src="@drawable/gyeonggi"
-        app:layout_constraintLeft_toLeftOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent" />
 
     <ImageView
         android:id="@+id/regionSeoul"
         android:layout_width="28dp"
         android:layout_height="33dp"
         android:layout_gravity="center"
-        android:layout_marginLeft="102dp"
-        android:layout_marginTop="170dp"
+        android:layout_marginEnd="99dp"
+        android:layout_marginBottom="186dp"
         android:src="@drawable/seoul"
-        app:layout_constraintLeft_toLeftOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
-    <!--
-    <ScrollView
-        android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent" />
 
-        <LinearLayout
-            android:id="@+id/regionLayout"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="vertical" />
-    </ScrollView>
-    -->
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_travel_record.xml
+++ b/app/src/main/res/layout/fragment_travel_record.xml
@@ -2,6 +2,7 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:background="@color/white"
     android:orientation="vertical">
 
     <androidx.recyclerview.widget.RecyclerView


### PR DESCRIPTION
지도 이미지를 setVisibility(View.GONE)를 통해 사라지게 했었는데,
애초에 fragment_travel_detail의 배경을 칠해버리면 굳이 visibility 세팅이 필요 없었다
(visibility를 조절 안 해도 뒷배경이 따라오지 않으니까)

겸사겸사 레이아웃 center-orient로 변경.