### PR TITLE
Fix: BackStack 버그 수정

### DIFF
--- a/app/src/main/java/com/example/madcamp24_week1/MainActivity.java
+++ b/app/src/main/java/com/example/madcamp24_week1/MainActivity.java
@@ -3,9 +3,12 @@ package com.example.madcamp24_week1;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.View;
+
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentTransaction;
 import androidx.viewpager2.widget.ViewPager2;
+
 import com.google.android.material.tabs.TabLayout;
 import com.google.android.material.tabs.TabLayoutMediator;
 
@@ -101,10 +104,12 @@ public class MainActivity extends AppCompatActivity implements ContactDetailFrag
     @Override
     public void onRegionSelected(int regionId) {
         Log.d("MainActivity", "Region selected: " + regionId);
+        getSupportFragmentManager().popBackStack("travel_record_fragment", FragmentManager.POP_BACK_STACK_INCLUSIVE);
+
         TravelRecordFragment travelRecordFragment = TravelRecordFragment.newInstance(regionId);
         FragmentTransaction transaction = getSupportFragmentManager().beginTransaction();
         transaction.replace(R.id.fragment_container, travelRecordFragment, "travel_record_fragment");
-        transaction.addToBackStack(null);
+        transaction.addToBackStack("travel_record_fragment");
         transaction.commit();
         findViewById(R.id.fragment_container).setVisibility(View.VISIBLE);
     }


### PR DESCRIPTION
지역별 TravelRecordFragment 뒤로가기 누르면 이전 것까지 보이던 버그 해결
- MainActivity 에서 새로운 TravelRecordFragment 인스턴스를 생성할 때, 생성 후 태그 없이 backstack에 push하고 이후 삭제 과정이 없어 이후 RegionFragment로 돌아가 새로이 TravelRecordFragment를 생성한 후 뒤로가기를 누르면 이전 TravelRecordFragment까지 누적되어 보였음
- TravelRecordFragment를 동일한 태그로 관리하여, 새로운 것을 생성하기 전에 backstack에 동일한 태그가 존재하면 해당 fragment는 삭제 후 새로운 TravelRecordFragment 인스턴스 생성

간단한 변경사항이고, 이외에 다른 액티비티/Fragment에 영향 주지 않는 것 확인했습니다. 시간되실 때 머지 부탁드립니다~